### PR TITLE
Set up library to better support custom sniffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor
+
+PixelUnion/Sniffs
+PixelUnion/Tests/Methods

--- a/PixelUnion/ruleset.xml
+++ b/PixelUnion/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Laravel Standards">
+<ruleset name="PixelUnion">
 
     <!--
        The name attribute of the ruleset tag is displayed
@@ -8,7 +8,7 @@
        except in this file, so it can contain information for
        developers who may change this file in the future.
     -->
-    <description>The Laravel Coding Standards</description>
+    <description>The Pixel Union PHP Coding Standards</description>
 
     <!--
     If no files or directories are specified on the command line

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 # PHP Validate
 
 A composer package that provides php validation in accordance with PRS-2
-standards, with configuration specific to Laravel.
+standards, along with any extra validation rules we choose.
 
 ## Installation
 
+This is a composer package but is hosted on github.
+
+Add this to `composer.json`:
 ```
-[coming soon]
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pixelunion/pxu-php-format"
+        }
+    ],
+
 ```
+
+And then this to `require-dev`:
+```
+        "pixelunion/pxu-php-format": "dev-master"
+```
+
+And then run `composer install` as per usual.
 
 ## Usage: CLI
 
@@ -23,7 +39,7 @@ Leaving blank will run against all files in a project.
 ## Usage: Manual
 
 To use our shared ruleset manually, point your `--standard` argument to
-`vendor/pixelunion/php-validate/config/laravel_phpcs_ruleset.xml`
+`vendor/pixelunion/pxu-php-format/PixelUnion/ruleset.xml`
 
 ## Usage with Travis CI
 
@@ -42,5 +58,16 @@ script:
   - ...
   - ...
 ```
+
+## Custom Sniffs
+
+Extra sniffs beyond the PSR-2 standard can be added in `PixelUnion/Sniffs`.
+Documentation for writing custom sniffs can be found in the
+[PHP_Codesniffer Wiki](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial#creating-the-sniff).
+Please organize custom sniffs under a category, for example `Sniffs/Operators/TernaryOperatorSniff.php`.
+
+### Testing custom sniffs
+
+(coming soon)
 
 

--- a/bin/php-format
+++ b/bin/php-format
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-phpcs --standard="$PWD/vendor/pixelunion/php-validate/config/laravel_phpcs_ruleset.xml" $1
+phpcs --standard="$PWD/PixelUnion/ruleset.xml" $1

--- a/bin/php-validate
+++ b/bin/php-validate
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-phpcs --standard="$PWD/vendor/pixelunion/php-validate/config/laravel_phpcs_ruleset.xml" $1
+phpcs --standard="$PWD/PixelUnion/ruleset.xml" $1

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,70 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "37ca731fe7e850f8cb8f2a732a7037bb",
+    "content-hash": "9254417788e00a77eaa3a8bead14f8c7",
+    "packages": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20 21:35:23"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}


### PR DESCRIPTION
This is some light rearrangement to put things into a structure where PHP_Codesniffer expects them when looking for custom sniff declarations.

This also sets the stage for being able to test any custom sniffs added.

Also updated the readme with installation instructions and custom sniff notes.